### PR TITLE
Add support for abstract classes without parameterless constructor

### DIFF
--- a/src/UnityAutoMoq.Tests/AbstractService.cs
+++ b/src/UnityAutoMoq.Tests/AbstractService.cs
@@ -1,0 +1,7 @@
+﻿namespace UnityAutoMoq.Tests
+{
+    public abstract class AbstractService
+    {
+        public AbstractService(IService service) { }
+    }
+}

--- a/src/UnityAutoMoq.Tests/AbstractServiceWithAmbiguousConstructor.cs
+++ b/src/UnityAutoMoq.Tests/AbstractServiceWithAmbiguousConstructor.cs
@@ -1,0 +1,8 @@
+﻿namespace UnityAutoMoq.Tests
+{
+    public abstract class AbstractServiceWithAmbiguousConstructor
+    {
+        public AbstractServiceWithAmbiguousConstructor(IService service) { }
+        public AbstractServiceWithAmbiguousConstructor(IAnotherService service) { }
+    }
+}

--- a/src/UnityAutoMoq.Tests/UnityAutoMoq.Tests.csproj
+++ b/src/UnityAutoMoq.Tests/UnityAutoMoq.Tests.csproj
@@ -94,6 +94,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AbstractService.cs" />
+    <Compile Include="AbstractServiceWithAmbiguousConstructor.cs" />
     <Compile Include="AnotherService.cs" />
     <Compile Include="CoreTdd.cs" />
     <Compile Include="IAnotherService.cs" />

--- a/src/UnityAutoMoq.Tests/UnityAutoMoq.Tests.csproj
+++ b/src/UnityAutoMoq.Tests/UnityAutoMoq.Tests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Service.cs" />
     <Compile Include="ServiceWithAbstractDependency.cs" />
     <Compile Include="UnityAutoMoqContainerFixture.cs" />
+    <Compile Include="YetAnotherService.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\UnityAutoMoq\UnityAutoMoq.csproj">

--- a/src/UnityAutoMoq.Tests/UnityAutoMoq.Tests.csproj
+++ b/src/UnityAutoMoq.Tests/UnityAutoMoq.Tests.csproj
@@ -86,12 +86,14 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnit.2.5.10.11092\lib\pnunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AbstractService.cs" />
     <Compile Include="AnotherService.cs" />
     <Compile Include="CoreTdd.cs" />
     <Compile Include="IAnotherService.cs" />
@@ -132,6 +134,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/UnityAutoMoq.Tests/UnityAutoMoqContainerFixture.cs
+++ b/src/UnityAutoMoq.Tests/UnityAutoMoqContainerFixture.cs
@@ -146,5 +146,14 @@ namespace UnityAutoMoq.Tests
 
             real.ShouldBeOfType<AnotherService>();
         }
+
+        [Test]
+        public void Can_mock_abstract_classes_without_parameterless_constructor()
+        {
+            var real = container.Resolve<AbstractService>();
+            var mock = container.GetMock<AbstractService>();
+
+            real.ShouldBeSameAs(mock.Object);
+        }
     }
 }

--- a/src/UnityAutoMoq.Tests/UnityAutoMoqContainerFixture.cs
+++ b/src/UnityAutoMoq.Tests/UnityAutoMoqContainerFixture.cs
@@ -148,12 +148,20 @@ namespace UnityAutoMoq.Tests
         }
 
         [Test]
-        public void Can_mock_abstract_classes_without_parameterless_constructor()
+        public void Can_get_abstract_class_without_parameterless_constructor_without_registering_it_first()
         {
-            var real = container.Resolve<AbstractService>();
-            var mock = container.GetMock<AbstractService>();
+            var mocked = container.Resolve<AbstractService>();
 
-            real.ShouldBeSameAs(mock.Object);
+            mocked.ShouldNotBeNull();
+        }
+
+        [Test]
+        public void Can_resolve_concrete_type_with_abstract_dependency_that_does_not_have_a_parameterless_constructor()
+        {
+            var mocked = container.Resolve<YetAnotherService>();
+
+            mocked.ShouldNotBeNull();
+            mocked.AbstractService.ShouldNotBeNull();
         }
     }
 }

--- a/src/UnityAutoMoq.Tests/UnityAutoMoqContainerFixture.cs
+++ b/src/UnityAutoMoq.Tests/UnityAutoMoqContainerFixture.cs
@@ -72,7 +72,7 @@ namespace UnityAutoMoq.Tests
         [Test]
         public void Should_apply_specified_default_value_when_specified_2()
         {
-            container = new UnityAutoMoqContainer{DefaultValue = DefaultValue.Empty};
+            container = new UnityAutoMoqContainer { DefaultValue = DefaultValue.Empty };
             var mocked = container.GetMock<IService>();
 
             mocked.DefaultValue.ShouldEqual(DefaultValue.Empty);
@@ -162,6 +162,14 @@ namespace UnityAutoMoq.Tests
 
             mocked.ShouldNotBeNull();
             mocked.AbstractService.ShouldNotBeNull();
+        }
+
+        [Test]
+        public void Abstract_class_with_ambiguous_constructor_throws_exception()
+        {
+            typeof(ResolutionFailedException).ShouldBeThrownBy(
+                () => container.Resolve<AbstractServiceWithAmbiguousConstructor>(), 
+                e => e.InnerException is InvalidOperationException);
         }
     }
 }

--- a/src/UnityAutoMoq.Tests/YetAnotherService.cs
+++ b/src/UnityAutoMoq.Tests/YetAnotherService.cs
@@ -1,0 +1,12 @@
+﻿namespace UnityAutoMoq.Tests
+{
+    class YetAnotherService : IAnotherService
+    {
+        public AbstractService AbstractService { get; private set; }
+
+        public YetAnotherService(AbstractService service)
+        {
+            AbstractService = service;
+        }
+    }
+}

--- a/src/UnityAutoMoq/UnityAutoMoqBuilderStrategy.cs
+++ b/src/UnityAutoMoq/UnityAutoMoqBuilderStrategy.cs
@@ -65,15 +65,15 @@ namespace UnityAutoMoq
                                 let numberOfParameters = c.GetParameters().Length
                                 group c by numberOfParameters into x
                                 orderby x.Key descending
-                                select x).ToList();
+                                select x).FirstOrDefault();
 
-            if (constructors.Count == 0)
+            if (constructors == null)
                 return new object[0];
-            if (constructors[0].Count() > 1)
-                throw new InvalidOperationException(string.Format("The type {0} has multiple constructor of length {1}. Unable to disambiguate.", t.Name, constructors[0].Key));
+            if (constructors.Count() > 1)
+                throw new InvalidOperationException(string.Format("The type {0} has multiple constructor of length {1}. Unable to disambiguate.", t.Name, constructors.Key));
 
             // Constructor with most arguments to follow Unity convention
-            return constructors[0].First().GetParameters().Select(x => autoMoqContainer.Resolve(x.ParameterType, null)).ToArray();
+            return constructors.First().GetParameters().Select(x => autoMoqContainer.Resolve(x.ParameterType, null)).ToArray();
         }
     }
 }


### PR DESCRIPTION
The case for abstract classes that don't have a parameterless constructor needs needs to be specifically handled, otherwise Castle throws an exception when we try to create the mock object.

I have added support for that and I throw an exception consistent with Unity's when the constructor to use is ambiguous.
